### PR TITLE
Fix template loading issues; make filter page visible; fix broken API call 

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -42,7 +42,6 @@ class GraduationByRaceSerializer(serializers.ModelSerializer):
 		fields = ('institution_id', 'academic_domain_id', 'number_of_program_offered')
 
 
-
 class InstitutionSerializer(serializers.ModelSerializer):
 	institution_name = serializers.CharField(
 		allow_blank=False,
@@ -57,16 +56,22 @@ class InstitutionSerializer(serializers.ModelSerializer):
 	zip_code = serializers.CharField(
 		allow_null=True
 	)
-	student_faculty_ratio = serializers.DecimalField(
-		allow_null=True,
-		max_digits=11,
-		decimal_places=8)
-
-	percent_admitted = serializers.DecimalField(
-		allow_null=True,
-		max_digits=10,
-		decimal_places=8
+	student_faculty_ratio = serializers.IntegerField(
+		allow_null=True
 	)
+	# student_faculty_ratio = serializers.DecimalField(
+	# 	allow_null=True,
+	# 	max_digits=11,
+	# 	decimal_places=8)
+	#
+	percent_admitted = serializers.IntegerField(
+		allow_null=True
+	)
+	# percent_admitted = serializers.DecimalField(
+	# 	allow_null=True,
+	# 	max_digits=10,
+	# 	decimal_places=8
+	# )
 
 	class Meta:
 		model = Institution
@@ -128,7 +133,7 @@ class InstitutionSerializer(serializers.ModelSerializer):
 
 		# If any existing AcademicProgram are not in updated list, delete them
 		new_ids = []
-		old_ids = academic_program.objects \
+		old_ids = AcademicProgram.objects \
 			.values_list('academic_domain_id', flat=True) \
 			.filter(institution_id__exact=institution_id)
 
@@ -139,7 +144,7 @@ class InstitutionSerializer(serializers.ModelSerializer):
 			if new_id in old_ids:
 				continue
 			else:
-				academic_program.objects \
+				AcademicProgram.objects \
 					.create(institution_id=institution_id, academic_domain_id=new_id)
 
 		# Delete old unmatched AcademicProgram entries

--- a/colleges/models.py
+++ b/colleges/models.py
@@ -91,15 +91,33 @@ class Institution(models.Model):
     institution_name = models.CharField(max_length=255)
     survey_year = models.CharField(max_length=4)
     zip_code = models.CharField(max_length=255, blank=True, null=True)
-    student_faculty_ratio = models.DecimalField(max_digits=10, decimal_places=0)
-    percent_admitted = models.DecimalField(max_digits=10, decimal_places=0)
+
+    student_faculty_ratio = models.IntegerField()
+    # student_faculty_ratio = models.DecimalField(max_digits=10, decimal_places=0)
+    percent_admitted = models.IntegerField()
+    # percent_admitted = models.DecimalField(max_digits=10, decimal_places=0)
 
     city = models.ForeignKey(City, on_delete=models.PROTECT)
     state = models.ForeignKey(State, on_delete=models.PROTECT)
 
-    academic_domain = models.ManyToManyField(AcademicDomain, through='AcademicProgram', related_name='institution_domains')
-    graduation_race_type = models.ManyToManyField(GraduationRaceType, through='GraduationByRace',related_name='institution_races')
-    library_collection_category = models.ManyToManyField(LibraryCollectionCategory, through='LibraryCollectionHolding',related_name='institution_libraries')
+    academic_domain = models.ManyToManyField(
+        AcademicDomain,
+        through='AcademicProgram',
+        blank=True,
+        related_name='institution_domains'
+    )
+    graduation_race_type = models.ManyToManyField(
+        GraduationRaceType,
+        through='GraduationByRace',
+        blank=True,
+        related_name='institution_races'
+    )
+    library_collection_category = models.ManyToManyField(
+        LibraryCollectionCategory,
+        through='LibraryCollectionHolding',
+        blank=True,
+        related_name='institution_libraries'
+    )
 
     class Meta:
         managed = False

--- a/colleges/templates/colleges/about.html
+++ b/colleges/templates/colleges/about.html
@@ -1,4 +1,4 @@
-
+{% extends 'colleges/base.html' %}
 
 {% block content %}
 

--- a/colleges/templates/colleges/base.html
+++ b/colleges/templates/colleges/base.html
@@ -1,6 +1,6 @@
-{% load static %}
-
 <!DOCTYPE html>
+
+{% load static %}
 
 <html lang="en">
   <head>
@@ -36,6 +36,9 @@
               <a class="nav-link" href="{% url 'institution' %}">Colleges</a>
             </li>
 
+            <li class="nav-item">
+              <a class="nav-link" href="{% url 'institution_search' %}">College Search</a>
+            </li>
 
             <li class="nav-item">
               <a class="nav-link" href="{% url 'login' %}">login</a>

--- a/colleges/templates/colleges/home.html
+++ b/colleges/templates/colleges/home.html
@@ -1,6 +1,4 @@
-{% load static %}
-
-<!DOCTYPE html>
+{% extends 'colleges/base.html' %}
 
 <h2>{% block title %}IPEDS Institutions{% endblock title %}</h2>
 

--- a/colleges/templates/colleges/index.html
+++ b/colleges/templates/colleges/index.html
@@ -1,6 +1,7 @@
+<!DOCTYPE html>
+
 {% load static %}
 
-<!DOCTYPE html>
 <html lang="en">
 
   <head>

--- a/colleges/templates/colleges/tables.html
+++ b/colleges/templates/colleges/tables.html
@@ -1,6 +1,7 @@
+<!DOCTYPE html>
+
 {% load static %}
 
-<!DOCTYPE html>
 <html lang="en">
 
   <head>

--- a/colleges/urls.py
+++ b/colleges/urls.py
@@ -6,6 +6,7 @@ urlpatterns = [
     path('about/', views.AboutPageView.as_view(), name='about'),
 
     path('institutions/', views.InstitutionListView.as_view(), name='institution'),
+    path('institutions/search/', views.InstitutionFilterView.as_view(), name='institution_search'),
     path('institutions/<int:pk>/', views.InstitutionDetailView.as_view(), name='institution_detail'),
 
     path('institutions/new/', views.InstitutionCreateView.as_view(), name='institution_new'),


### PR DESCRIPTION
This PR addresses a set of issues that disrupted the grading of the final project:

* template files missing extend from base tags
* missing filter page (code present but not wired up)
* API GET failing on bad data type selection

### Examples of errors encountered

This is how the site displayed when I started up the server:
![image](https://user-images.githubusercontent.com/83268/50385924-7eeac480-06ab-11e9-810c-e893f8ae2363.png)

`student_faculty_ratio` and `percent_admitted` properties should be typed as integers not decimals based on values stored in the database:
![image](https://user-images.githubusercontent.com/83268/50385932-9a55cf80-06ab-11e9-8b32-92eb53897592.png)

